### PR TITLE
Handle vSphere elements with spaces in their names

### DIFF
--- a/pack/cluster/commands.cfg
+++ b/pack/cluster/commands.cfg
@@ -11,21 +11,21 @@
 ##ARG1 and take cpu, io, net or mem
 define command{
        command_name     check_cluster_cpu
-       command_line     $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -C $HOSTALIAS$ -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -s usage -c $_HOSTCLUSTER_CPU_CRIT$ -w $_HOSTCLUSTER_CPU_WARN$  -l cpu -i $_HOSTCLUSTER_INTERVAL$ -S $_HOSTVCENTER_SESSION$
+       command_line     $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -C "$HOSTALIAS$" -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -s usage -c $_HOSTCLUSTER_CPU_CRIT$ -w $_HOSTCLUSTER_CPU_WARN$  -l cpu -i $_HOSTCLUSTER_INTERVAL$ -S $_HOSTVCENTER_SESSION$
 }
 
 define command{
        command_name     check_cluster_issues
-       command_line     $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -C $HOSTALIAS$ -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l runtime -s issues -i $_HOSTCLUSTER_INTERVAL$ -S $_HOSTVCENTER_SESSION$
+       command_line     $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -C "$HOSTALIAS$" -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l runtime -s issues -i $_HOSTCLUSTER_INTERVAL$ -S $_HOSTVCENTER_SESSION$
 }
 
 define command{
        command_name     check_cluster_mem
-       command_line     $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -C $HOSTALIAS$ -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l mem -s usage -c $_HOSTCLUSTER_MEM_CRIT$ -w $_HOSTCLUSTER_MEM_WARN$ -i $_HOSTCLUSTER_INTERVAL$ -S $_HOSTVCENTER_SESSION$
+       command_line     $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -C "$HOSTALIAS$" -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l mem -s usage -c $_HOSTCLUSTER_MEM_CRIT$ -w $_HOSTCLUSTER_MEM_WARN$ -i $_HOSTCLUSTER_INTERVAL$ -S $_HOSTVCENTER_SESSION$
 }
 
 # Check host alive for vmware cluster
 define command{
        command_name     check_cluster_alive
-       command_line     $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -C $HOSTALIAS$ -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l runtime -s listhost -c $_HOSTCLUSTER_HOSTS_CRIT$ -w $_HOSTCLUSTER_HOSTS_WARN$ -S $_HOSTVCENTER_SESSION$
+       command_line     $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -C "$HOSTALIAS$" -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l runtime -s listhost -c $_HOSTCLUSTER_HOSTS_CRIT$ -w $_HOSTCLUSTER_HOSTS_WARN$ -S $_HOSTVCENTER_SESSION$
 }

--- a/pack/esx/commands.cfg
+++ b/pack/esx/commands.cfg
@@ -11,33 +11,33 @@
 ##ARG1 and take cpu, io, net or mem
 define command{
        command_name     check_esx_host
-       command_line     $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -H $HOSTALIAS$ -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l $ARG1$ -S $_HOSTVCENTER_SESSION$
+       command_line     $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -H "$HOSTALIAS$" -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l $ARG1$ -S $_HOSTVCENTER_SESSION$
 }
 
 define command{
         command_name    check_esx_vm
-        command_line    $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -N $HOSTALIAS$ -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l $ARG1$ -S $_HOSTVCENTER_SESSION$
+        command_line    $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -N "$HOSTALIAS$" -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l $ARG1$ -S $_HOSTVCENTER_SESSION$
 }
 
 
 define command{
        command_name     check_esx_host_cpu
-       command_line     $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -H $HOSTALIAS$ -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -s usage -c $_HOSTESX_CPU_CRIT$ -w $_HOSTESX_CPU_WARN$  -l cpu -S $_HOSTVCENTER_SESSION$
+       command_line     $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -H "$HOSTALIAS$" -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -s usage -c $_HOSTESX_CPU_CRIT$ -w $_HOSTESX_CPU_WARN$  -l cpu -S $_HOSTVCENTER_SESSION$
 }
 
 define command{
        command_name     check_esx_host_io
-       command_line     $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -H $HOSTALIAS$ -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l io -S $_HOSTVCENTER_SESSION$
+       command_line     $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -H "$HOSTALIAS$" -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l io -S $_HOSTVCENTER_SESSION$
 }
 
 define command{
        command_name     check_esx_host_net
-       command_line     $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -H $HOSTALIAS$ -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l net -S $_HOSTVCENTER_SESSION$
+       command_line     $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -H "$HOSTALIAS$" -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l net -S $_HOSTVCENTER_SESSION$
 }
 
 
 define command{
        command_name     check_esx_host_mem
-       command_line     $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -H $HOSTALIAS$ -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l mem -s usage -c $_HOSTESX_MEM_CRIT$ -w $_HOSTESX_MEM_WARN$ -S $_HOSTVCENTER_SESSION$
+       command_line     $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -H "$HOSTALIAS$" -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l mem -s usage -c $_HOSTESX_MEM_CRIT$ -w $_HOSTESX_MEM_WARN$ -S $_HOSTVCENTER_SESSION$
 }
 

--- a/pack/vm/commands.cfg
+++ b/pack/vm/commands.cfg
@@ -9,48 +9,48 @@
 # Now for the VMs
 define command{
         command_name    check_esx_vm_runtime
-        command_line    $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -N $HOSTALIAS$ -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l runtime -S $_HOSTVCENTER_SESSION$
+        command_line    $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -N "$HOSTALIAS$" -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l runtime -S $_HOSTVCENTER_SESSION$
 
 }
 
 define command{
         command_name    check_esx_vm_cpu_all
-        command_line    $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -N $HOSTALIAS$ -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l cpu -S $_HOSTVCENTER_SESSION$
+        command_line    $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -N "$HOSTALIAS$" -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l cpu -S $_HOSTVCENTER_SESSION$
 }
 
 define command{
         command_name    check_esx_vm_io_all
-        command_line    $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -N $HOSTALIAS$ -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l io -S $_HOSTVCENTER_SESSION$
+        command_line    $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -N "$HOSTALIAS$" -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l io -S $_HOSTVCENTER_SESSION$
 }
 
 define command{
         command_name    check_esx_vm_net_all
-        command_line    $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -N $HOSTALIAS$ -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l net -S $_HOSTVCENTER_SESSION$
+        command_line    $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -N "$HOSTALIAS$" -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l net -S $_HOSTVCENTER_SESSION$
 }
 
 define command{
         command_name    check_esx_vm_mem_all
-        command_line    $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -N $HOSTALIAS$ -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l mem -S $_HOSTVCENTER_SESSION$
+        command_line    $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -N "$HOSTALIAS$" -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l mem -S $_HOSTVCENTER_SESSION$
 }
 
 define command{
         command_name    check_esx_vm_alive
-        command_line    $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -N $HOSTALIAS$ -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l runtime -s state -S $_HOSTVCENTER_SESSION$
+        command_line    $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -N "$HOSTALIAS$" -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l runtime -s state -S $_HOSTVCENTER_SESSION$
 
 }
 
 define command{
         command_name    check_esx_vm_cpu
-        command_line    $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -N $HOSTALIAS$ -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l cpu -s usage -c $_HOSTVM_CPU_CRIT$ -w $_HOSTVM_CPU_WARN$ -S $_HOSTVCENTER_SESSION$
+        command_line    $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -N "$HOSTALIAS$" -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l cpu -s usage -c $_HOSTVM_CPU_CRIT$ -w $_HOSTVM_CPU_WARN$ -S $_HOSTVCENTER_SESSION$
 }
 
 define command{
         command_name    check_esx_vm_mem
-        command_line    $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -N $HOSTALIAS$ -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l mem -s usage -c $_HOSTVM_MEM_CRIT$ -w $_HOSTVM_MEM_WARN$ -S $_HOSTVCENTER_SESSION$
+        command_line    $PLUGINSDIR$/check_esx3.pl -D $_HOSTVCENTER$ -N "$HOSTALIAS$" -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -l mem -s usage -c $_HOSTVM_MEM_CRIT$ -w $_HOSTVM_MEM_WARN$ -S $_HOSTVCENTER_SESSION$
 }
 
 define command{
         command_name    check_esx_vm_disk
-        command_line    $PLUGINSDIR$/check_disk_vcenter.pl -D $_HOSTVCENTER$ -N $HOSTALIAS$ -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -w $_HOSTVM_DISK_WARN$ -c $_HOSTVM_DISK_CRIT$ -e $_HOSTVM_DISK_EXCL$ -S $_HOSTVCENTER_SESSION$
+        command_line    $PLUGINSDIR$/check_disk_vcenter.pl -D $_HOSTVCENTER$ -N "$HOSTALIAS$" -u $_HOSTVCENTER_LOGIN$ -p $_HOSTVCENTER_PASSWORD$ -w $_HOSTVM_DISK_WARN$ -c $_HOSTVM_DISK_CRIT$ -e $_HOSTVM_DISK_EXCL$ -S $_HOSTVCENTER_SESSION$
 }
 


### PR DESCRIPTION
Sometimes you encounter vSphere elements like clusters, vm, etc. with spaces in their names. This can be handled with proper quoting.

I didn't see necessity in quoting other arguments.
